### PR TITLE
Change environment for bin/install to /bin/bash from /bin/sh

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 echo '##### Installing Modeify #####'
 


### PR DESCRIPTION
On some systems /bin/sh does not have the source command.