### PR TITLE
Arlington fixes

### DIFF
--- a/lib/plan/index.js
+++ b/lib/plan/index.js
@@ -63,6 +63,8 @@ app.get('/', function (req, res) {
 
   // construct the R5 query, if applicable
   if (queryR5) {
+    // allow walk as direct mode if none specified
+    const directModes = req.query.directModes.length === 0 ? [ 'WALK' ] : req.query.directModes
     plans.push(r5.requestPlan({
       from,
       to,
@@ -70,7 +72,7 @@ app.get('/', function (req, res) {
       fromTime: req.query.startTime,
       toTime: req.query.endTime,
       accessModes: req.query.accessModes,
-      directModes: req.query.directModes,
+      directModes: directModes,
       egressModes: req.query.egressModes,
       transitModes: req.query.transitModes,
       bikeTrafficStress: req.query.bikeTrafficStress,

--- a/lib/plan/profile-filter.js
+++ b/lib/plan/profile-filter.js
@@ -123,9 +123,7 @@ function filterTripsWithShortTransitLegs (opts) {
 
 function filterExcessiveTransitOptions (opts) {
   var comparator = function (a, b) {
-    // FIXME: OTP and R5 responses should be interchangeable
-    if (a.time && b.time) return b.time - a.time
-    return b.itinerary[0].duration - a.itinerary[0].duration
+    return b.score - a.score
   }
   var bikeToTransitOpts = new PriorityQueue(comparator)
   var bikeshareToTransitOpts = new PriorityQueue(comparator)
@@ -164,7 +162,9 @@ function filterExcessiveTransitOptions (opts) {
     count++
   }
 
-  return opts
+  return opts.sort(function (a, b) {
+    return a.score - b.score
+  })
 }
 
 /**


### PR DESCRIPTION
Addresses two fixes requested by Arlington following migration to R5:
- Improved sorting of trip options for ranked display. Fixes bug where sorted results were inadvertently reordered by the filtering logic
- Ensure that transit results are displayed in case where only transit modes are selected. If no access mode is selected, walk-transit is assumed