### PR TITLE
Make links created in create-link work

### DIFF
--- a/client/plan/index.js
+++ b/client/plan/index.js
@@ -282,6 +282,7 @@ Plan.prototype.setAddress = function (name, locationData, callback) {
           return callback(err)
         } else {
           location.coordinate(res)
+          changes[name] = locationData
           changes[name + '_ll'] = res
           changes[name + '_valid'] = true
           plan.set(changes)


### PR DESCRIPTION
Seems like the address in the url parameter wasn’t making it all the way through the system.